### PR TITLE
Expose footnote.def_count and fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,6 @@ progit/
 bench/benchinput.md
 test/afl_results/
 
+.zig-cache
 zig-cache
 zig-out

--- a/src/cmark-gfm.h
+++ b/src/cmark-gfm.h
@@ -464,6 +464,11 @@ CMARK_GFM_EXPORT const char *cmark_node_get_title(cmark_node *node);
  */
 CMARK_GFM_EXPORT int cmark_node_set_title(cmark_node *node, const char *title);
 
+/** Returns the definition count of a footnote definition 'node'.
+    Returns 0 if called on a node that is not a footnote definition.
+ */
+CMARK_GFM_EXPORT int cmark_node_get_footnote_def_count(cmark_node *node);
+
 /** Returns the literal "on enter" text for a custom 'node', or
     an empty string if no on_enter is set.  Returns NULL if called
     on a non-custom node.

--- a/src/node.c
+++ b/src/node.c
@@ -713,6 +713,18 @@ int cmark_node_set_title(cmark_node *node, const char *title) {
   return 0;
 }
 
+int cmark_node_get_footnote_def_count(cmark_node *node) {
+  if (node == NULL) {
+    return 0;
+  }
+
+  if (node->type == CMARK_NODE_FOOTNOTE_DEFINITION) {
+    return node->footnote.def_count;
+  }
+  
+  return 0;
+}
+
 const char *cmark_node_get_on_enter(cmark_node *node) {
   if (node == NULL) {
     return NULL;


### PR DESCRIPTION
Rendering footnotes properly requires access to `cmark_node->footnote.def_count`, which cmark-gfm does not expose.